### PR TITLE
Add missing Sync method

### DIFF
--- a/file.go
+++ b/file.go
@@ -68,6 +68,10 @@ func (f *InMemoryFile) Open() error {
 	return nil
 }
 
+func (f *InMemoryFile) Sync() error {
+        return nil
+}
+
 func (f *InMemoryFile) Close() (err error) {
 	atomic.StoreInt64(&f.at, 0)
 	f.closed = true


### PR DESCRIPTION
InMemoryFile no longer implements afero File interface, with the following error being raised when trying to import af3ro:

`*InMemoryFile does not implement afero.File (missing Sync method)`

This adds the missing method to stop the error from happening, not sure if the implementation is correct though.
